### PR TITLE
2.16.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Variables used in the `build` installation process.
 - **wkhtmltopdf_dir_chroot**: directory to setup chroot environment.
 - **wkhtmltopdf_dir_source**: directory where to store the source tarball.
 - **wkhtmltopdf_dir_source_version**: directory where to extract the tarball or clone the git repository.
-- **wkhtmltopdf_source_dependencies**: list of packages needed to build the software.
+- **wkhtmltopdf_force_build**: compile software.
+- **wkhtmltopdf_runtime_dependencies**: list of packages needed to run the software.
 - **wkhtmltopdf_tarball_download_url**: URL to download tarball.
-- **wkhtmltopdf_force_build**: .
 - **wkhtmltopdf_slug**: git repository slug to be cloned.
 - **wkhtmltopdf_tarball**: tarball basename.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,7 +33,17 @@ wkhtmltopdf_dir_source_version: "{{ wkhtmltopdf_dir_source }}/wkhtmltox-{{ wkhtm
 wkhtmltopdf_force_build: no
 
 wkhtmltopdf_source_dependencies:
-  - xorg
+  - fontconfig
+  - freetype
+  - glibc
+  - libstdc++
+  - libX11
+  - libXext
+  - libXrender
+  - openssl
+  - xorg-x11-fonts-Type1
+  - xorg-x11-fonts-75dpi
+  - zlib
 
 wkhtmltopdf_slug: wkhtmltopdf/wkhtmltopdf
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,7 +32,7 @@ wkhtmltopdf_dir_source_version: "{{ wkhtmltopdf_dir_source }}/wkhtmltox-{{ wkhtm
 
 wkhtmltopdf_force_build: no
 
-wkhtmltopdf_source_dependencies:
+wkhtmltopdf_runtime_dependencies:
   - fontconfig
   - freetype
   - glibc

--- a/tasks/source/debug.yml
+++ b/tasks/source/debug.yml
@@ -19,7 +19,7 @@
     - wkhtmltopdf_dir_source
     - wkhtmltopdf_dir_source_version
     - wkhtmltopdf_force_build
-    - wkhtmltopdf_source_dependencies
+    - wkhtmltopdf_runtime_dependencies
     - wkhtmltopdf_slug
     - wkhtmltopdf_tarball
     - wkhtmltopdf_tarball_download_url

--- a/tasks/source/main.yml
+++ b/tasks/source/main.yml
@@ -22,7 +22,7 @@
   become: yes
   when: (task_version_installed is defined and task_version_installed.rc != 0)
   with_items:
-    - "{{ wkhtmltopdf_source_dependencies }}"
+    - "{{ wkhtmltopdf_runtime_dependencies }}"
 
 - name: build | download and install source (using tarball or git)
   include: "{{ wkhtmltopdf_build }}.yml"

--- a/tasks/source/validation.yml
+++ b/tasks/source/validation.yml
@@ -18,7 +18,7 @@
     - wkhtmltopdf_dir_source
     - wkhtmltopdf_dir_source_version
     - wkhtmltopdf_force_build
-    - wkhtmltopdf_source_dependencies
+    - wkhtmltopdf_runtime_dependencies
     - wkhtmltopdf_slug
     - wkhtmltopdf_tarball
     - wkhtmltopdf_tarball_download_url


### PR DESCRIPTION
- renamed `wkhtmltopdf_source_dependencies` to `wkhtmltopdf_runtime_dependencies`
- added more packages to the list of `wkhtmltopdf_runtime_dependencies`
